### PR TITLE
Adjust function calling from react query library

### DIFF
--- a/client/src/utils/refetchQueries.js
+++ b/client/src/utils/refetchQueries.js
@@ -1,21 +1,11 @@
 import { queryCache } from 'react-query';
 
 function refetchQueries() {
-  queryCache.invalidateQueries('user', {
-    force: true,
-  });
-  queryCache.invalidateQueries('toWatchList', {
-    force: true,
-  });
-  queryCache.invalidateQueries('watchedList', {
-    force: true,
-  });
-  queryCache.invalidateQueries('recsGenres', {
-    force: true,
-  });
-  queryCache.invalidateQueries('recsNetworks', {
-    force: true,
-  });
+  queryCache.invalidateQueries('user');
+  queryCache.invalidateQueries('toWatchList');
+  queryCache.invalidateQueries('watchedList');
+  queryCache.invalidateQueries('recsGenres');
+  queryCache.invalidateQueries('recsNetworks');
 }
 
 export default refetchQueries;

--- a/client/src/utils/refetchQueries.js
+++ b/client/src/utils/refetchQueries.js
@@ -1,19 +1,19 @@
 import { queryCache } from 'react-query';
 
 function refetchQueries() {
-  queryCache.refetchQueries('user', {
+  queryCache.invalidateQueries('user', {
     force: true,
   });
-  queryCache.refetchQueries('toWatchList', {
+  queryCache.invalidateQueries('toWatchList', {
     force: true,
   });
-  queryCache.refetchQueries('watchedList', {
+  queryCache.invalidateQueries('watchedList', {
     force: true,
   });
-  queryCache.refetchQueries('recsGenres', {
+  queryCache.invalidateQueries('recsGenres', {
     force: true,
   });
-  queryCache.refetchQueries('recsNetworks', {
+  queryCache.invalidateQueries('recsNetworks', {
     force: true,
   });
 }


### PR DESCRIPTION
The library react-query updated a function call connected with the querycache to refetch queries. 
-> [PR for new Version](https://github.com/tannerlinsley/react-query/pull/585)
-> [Doc for new method to refetch queries](https://react-query.tanstack.com/docs/guides/query-invalidation)